### PR TITLE
#67 表示名の変更機能

### DIFF
--- a/04.source/ideash/app/assets/stylesheets/shared.scss
+++ b/04.source/ideash/app/assets/stylesheets/shared.scss
@@ -163,26 +163,29 @@ body {
   height: 50%;
 }
 
-.chat-area{
+.chat-area {
   //border: #1B1C1D 1px solid;
   height: 90%;
   padding-top: 1vh;
   overflow: auto;
 }
 
-.chat-input{
+.chat-input {
   width: 100%;
   margin-top: 10px;
   margin-bottom: 5px;
 }
 
-.chat_username{
+.chat_username {
   margin: 5px !important;
 }
 
-.chat_message
-{
+.chat_message {
   display: block !important;
+  margin: 2px !important;
+  word-break: break-all;
+  left: 5%;
+  width: 85%;
 }
 
 .memo-content {

--- a/04.source/ideash/app/controllers/users/registrations_controller.rb
+++ b/04.source/ideash/app/controllers/users/registrations_controller.rb
@@ -67,4 +67,24 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def after_sign_in_path_for(resource)
     idea_home_path
   end
+
+  def profile_edit
+    render('ideas/account')
+  end
+
+  def profile_update
+    current_user.assign_attributes(account_update_params)
+    if current_user.save
+      redirect_to profile_edit_path
+    else
+      render "ideas/account"
+    end
+  end
+
+  protected
+
+  before_action :configure_account_update_params
+  def configure_account_update_params
+    devise_parameter_sanitizer.permit(:account_update, keys: [:user_name])
+  end
 end

--- a/04.source/ideash/app/javascript/packs/idea/brainstorming_channel.js
+++ b/04.source/ideash/app/javascript/packs/idea/brainstorming_channel.js
@@ -25,9 +25,7 @@ $(document).on("turbolinks:load", function () {
                     }
                 } else if (query['mode'] == 'add') {
                     let add = query["add"]
-                    var escapeHTML = function (val) {
-                        return $('<div />').text(val).html();
-                    };
+
                     const idea_text = escapeHTML(add["content"]);
 
                     if (idea_text == null || idea_text == "") {
@@ -47,22 +45,22 @@ $(document).on("turbolinks:load", function () {
                     localStorage.setItem('card_id', id);
                 } else if (query['mode'] == 'chat') {
                     var user_id = 'chatuser_' + query['user_id']
-                    var chat_text
-
+                    var user_name = escapeHTML(query['chat']['user_name'])
+                    var chat_text = escapeHTML(query['chat']['content']);
+                    var chat_div;
                     if ($('#user_id').val() == query['user_id']) {
-                        chat_text = `<div class="ui right pointing label chat_message">${query['chat']['content']}</div>`
+                        chat_div = `<div class="ui right pointing label chat_message">${chat_text}</div>`
                     } else {
-                        chat_text = `<div class="ui left pointing label chat_message">${query['chat']['content']}</div>`
+                        chat_div = `<div class="ui left pointing label chat_message">${chat_text}</div>`
                     }
-
                     if (user_id != $('.chat_content').first().attr('name')) {
                         $('.chat_contents').first().prepend(`
                         <div class="chat_content" name="chatuser_${query['user_id']}">
-                            <h6 class="chat_username">${query['chat']['user_name']}</h6>
+                            <h6 class="chat_username">${user_name}</h6>
                         </div>
                     `)
                     }
-                    $('.chat_username').first().after(chat_text)
+                    $('.chat_username').first().after(chat_div)
 
                 }
             },
@@ -98,3 +96,8 @@ $(document).on("turbolinks:load", function () {
         }
     }
 });
+
+// NOTE: エスケープ処理
+const escapeHTML = function (val) {
+    return $('<div />').text(val).html();
+};

--- a/04.source/ideash/app/javascript/packs/idea/brainstorming_channel.js
+++ b/04.source/ideash/app/javascript/packs/idea/brainstorming_channel.js
@@ -50,7 +50,7 @@ $(document).on("turbolinks:load", function () {
                     var chat_text
 
                     if ($('#user_id').val() == query['user_id']) {
-                        chat_text = `<div class="ui right pointing label chat-message">${query['chat']['content']}</div>`
+                        chat_text = `<div class="ui right pointing label chat_message">${query['chat']['content']}</div>`
                     } else {
                         chat_text = `<div class="ui left pointing label chat_message">${query['chat']['content']}</div>`
                     }
@@ -62,7 +62,7 @@ $(document).on("turbolinks:load", function () {
                         </div>
                     `)
                     }
-                    $('.chat_username').first().append(chat_text)
+                    $('.chat_username').first().after(chat_text)
 
                 }
             },
@@ -77,11 +77,9 @@ $(document).on("turbolinks:load", function () {
                 );
             }
         });
-
         $(document).on('keypress', '[data-behavior~=idea_speaker]', function (event) {
             if (event.keyCode === 13) {
                 if (event.target.value === "") return false
-                console.log(event.target.id)
                 let content = {
                     content: event.target.value
                 };

--- a/04.source/ideash/app/views/ideas/account.html.erb
+++ b/04.source/ideash/app/views/ideas/account.html.erb
@@ -17,7 +17,7 @@
           </tbody>
         </table>
         <div class="actions">
-          <%= f.submit "Update" %>
+          <%= f.submit "Update", class: "ui primary button" %>
         </div>
       </div>
     </div>

--- a/04.source/ideash/app/views/ideas/account.html.erb
+++ b/04.source/ideash/app/views/ideas/account.html.erb
@@ -1,40 +1,27 @@
 <%= render :partial => 'shared/header' %>
-
-<div class="home_body" id="home_body">
-  <div class="account_segment">
-    <div class="account_name">username</div>
-    <div class="account_setting">
-      <table class="ui very basic table">
-        <tbody>
-        <tr>
-          <td>Name</td>
-          <td>
-            <div class="ui input">
-              <input type="text">
-            </div>
-          </td>
-        </tr>
-        <tr>
-          <td>E-mail address</td>
-          <td>
-            <div class="ui input">
-              <input type="text">
-            </div>
-          </td>
-        </tr>
-        <tr>
-          <td>Pass word</td>
-          <td>
-            <div class="ui input">
-              <input type="password">
-            </div>
-          </td>
-        </tr>
-        </tbody>
-      </table>
+<%= form_for current_user, url: {action: 'profile_update'} do |f| %>
+  <div class="home_body" id="home_body">
+    <div class="account_segment">
+      <div class="account_name">アカウント設定</div>
+      <div class="account_setting">
+        <table class="ui very basic table">
+          <tbody>
+          <tr>
+            <td><%= f.label :user_name %></td>
+            <td>
+              <div class="ui input">
+                <%= f.text_field :user_name %>
+              </div>
+            </td>
+          </tr>
+          </tbody>
+        </table>
+        <div class="actions">
+          <%= f.submit "Update" %>
+        </div>
+      </div>
     </div>
   </div>
-</div>
-
+<% end %>
 <%# JSが書かれているため最後に書くこと %>
 <%= render :partial => 'shared/homemenu' %>

--- a/04.source/ideash/app/views/shared/_debug_menu.html.erb
+++ b/04.source/ideash/app/views/shared/_debug_menu.html.erb
@@ -14,6 +14,10 @@
               USER-ID:<%= current_user.id %>
             </div>
             <div class="item">
+              <i class="users icon"></i>
+              USER-NAME:<%= current_user.user_name %>
+            </div>
+            <div class="item">
               <i class="mail icon"></i>
               EMAIL:<%= current_user.email %>
             </div>

--- a/04.source/ideash/app/views/shared/_homemenu.html.erb
+++ b/04.source/ideash/app/views/shared/_homemenu.html.erb
@@ -9,7 +9,7 @@
     <%= link_to "メモ", idea_memo_new_path, class: "item home-menu" %>
   </div>
   <%= link_to "履歴", idea_history_path, class: "item home-menu" %>
-  <%= link_to "アカウント", idea_account_path, class: "item home-menu" %>
+  <%= link_to "アカウント", profile_edit_path, class: "item home-menu" %>
   <%= link_to "サインアウト", account_signout_path, class: "item home-menu" %>
   <small class="copyright">© 2020 by KUGATech team 5K</small>
 </div>¬

--- a/04.source/ideash/app/views/users/registrations/edit.html.erb
+++ b/04.source/ideash/app/views/users/registrations/edit.html.erb
@@ -1,7 +1,12 @@
 <h2>Edit <%= resource_name.to_s.humanize %></h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: {method: :put}) do |f| %>
+<%= form_for(resource, as: resource_name, url: account_profile_edit_path(resource_name), html: {method: :put}) do |f| %>
   <%= render "users/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :user_name %><br/>
+    <%= f.text_field :user_name, autofocus: true, autocomplete: "name" %>
+  </div>
 
   <div class="field">
     <%= f.label :email %><br/>
@@ -38,6 +43,6 @@
 
 <h3>Cancel my account</h3>
 
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: {confirm: "Are you sure?"}, method: :delete %></p>
+<!--<p>Unhappy? <%#= button_to "Cancel my account", registration_path(resource_name), data: {confirm: "Are you sure?"}, method: :delete %></p>-->
 
 <%= link_to "Back", :back %>

--- a/04.source/ideash/config/routes.rb
+++ b/04.source/ideash/config/routes.rb
@@ -11,11 +11,12 @@
 #                  account_profile_edit GET    /account/profile_edit(.:format)                                                          account#profile_edit
 #                     user_confirmation GET    /user/confirmation(.:format)                                                             users/confirmations#show
 #                                       POST   /user/confirmation(.:format)                                                             users/confirmations#create
+#                          profile_edit GET    /account/edit(.:format)                                                                  users/registrations#profile_edit
+#                        profile_update PATCH  /profile_update(.:format)                                                                users/registrations#profile_update
 #                                  idea GET    /idea(.:format)                                                                          ideas#home
 #                             idea_home GET    /idea/home(.:format)                                                                     ideas#home
 #                          idea_history GET    /idea/history(.:format)                                                                  ideas#history
 #                         idea_category GET    /idea/category(.:format)                                                                 ideas#category
-#                          idea_account GET    /idea/account(.:format)                                                                  ideas#account
 #                         idea_memo_new GET    /idea/memo/new(.:format)                                                                 memo#new
 #                                       POST   /idea/memo/new(.:format)                                                                 memo#new
 #                             idea_memo POST   /idea/memo(.:format)                                                                     memo#create
@@ -57,6 +58,7 @@ Rails.application.routes.draw do
 
   # INFO: devise(ユーザ認証関連)
   devise_for :users, skip: :all
+  # devise_for :users
   devise_scope :user do
     get 'account/signin' => 'users/sessions#new'
     post 'account/signin' => 'users/sessions#create'
@@ -67,6 +69,10 @@ Rails.application.routes.draw do
     # get 'user/confirmation/new' => 'users/confirmations#new'
     get 'user/confirmation' => 'users/confirmations#show'
     post 'user/confirmation' => 'users/confirmations#create'
+    # INFO: アカウント設定
+    # get 'account/edit' => 'users/registrations#edit'
+    get 'account/edit', to: 'users/registrations#profile_edit', as: 'profile_edit'
+    patch 'profile_update', to: 'users/registrations#profile_update', as: 'profile_update'
   end
 
   # INFO: ユーザのホーム画面
@@ -74,7 +80,7 @@ Rails.application.routes.draw do
   get 'idea/home' => 'ideas#home'
   get 'idea/history' => 'ideas#history'
   get 'idea/category' => 'ideas#category'
-  get 'idea/account' => 'ideas#account'
+  # get 'idea/account' => 'ideas#account'
 
   # INFO: メモ
   get 'idea/memo/new' => 'memo#new'


### PR DESCRIPTION
・アカウントページに表示名の変更機能を追加(#67)
　・メールアドレスとパスワードは表示を削除
・チャット欄のレイアウトを修正
　・吹き出し部分が隠れないように修正
　・英語(アルファベット)を書いた時にはみ出さないように修正
　・自身のチャットを連投した場合でも少し隙間を開けるように修正
・チャット機能のXSS脆弱性を修正 (#105)
　・名前欄でのXSS脆弱性
　・チャット欄でのXSS脆弱性
・デバッグメニューにuser_nameを追加