### PR TITLE
#248 #293 JS周りの構造を修正

### DIFF
--- a/04.source/ideash/app/javascript/packs/application.js
+++ b/04.source/ideash/app/javascript/packs/application.js
@@ -20,7 +20,9 @@ require('./common/check_controller_action')
 // 各コントローラー用
 // idea新規作成画面
 require('./common/new')
-//brainstormingの編集画面
+//top
+require('./top')
+//brainstormingのedit画面
 require('./idea/brainstorming_channel')
 
 // Uncomment to copy all static images under ../images to the output folder and reference

--- a/04.source/ideash/app/javascript/packs/application.js
+++ b/04.source/ideash/app/javascript/packs/application.js
@@ -16,6 +16,7 @@ import 'fomantic-ui-css/semantic.min.css'
 
 // 共有js
 require('./common/check_controller_action')
+require('./shared')
 
 // 各コントローラー用
 // idea新規作成画面

--- a/04.source/ideash/app/javascript/packs/application.js
+++ b/04.source/ideash/app/javascript/packs/application.js
@@ -18,7 +18,6 @@ import 'fomantic-ui-css/semantic.min.css'
 require('fomantic-ui-css/semantic.min')
 
 // 共有js
-// require('./common/check_controller_action')
 require('./shared')
 require('./shared/_right_menu')
 

--- a/04.source/ideash/app/javascript/packs/application.js
+++ b/04.source/ideash/app/javascript/packs/application.js
@@ -20,6 +20,8 @@ require('./common/check_controller_action')
 // 各コントローラー用
 // idea新規作成画面
 require('./common/new')
+//brainstormingの編集画面
+require('./idea/brainstorming_channel')
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/04.source/ideash/app/javascript/packs/application.js
+++ b/04.source/ideash/app/javascript/packs/application.js
@@ -22,9 +22,10 @@ require('./common/check_controller_action')
 require('./common/new')
 //top
 require('./top')
+//memo#memo
+require('./memo/memo')
 //brainstorming#edit
 require('./idea/brainstorming_channel')
-
 //word_gacha
 require('./idea/word_gacha')
 

--- a/04.source/ideash/app/javascript/packs/application.js
+++ b/04.source/ideash/app/javascript/packs/application.js
@@ -14,6 +14,13 @@ require("jquery-ui")
 // fomantic-uiの読み込み
 import 'fomantic-ui-css/semantic.min.css'
 
+// 共有js
+require('./common/check_controller_action')
+
+// 各コントローラー用
+// idea新規作成画面
+require('./common/new')
+
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)
 // or the `imagePath` JavaScript helper below.

--- a/04.source/ideash/app/javascript/packs/application.js
+++ b/04.source/ideash/app/javascript/packs/application.js
@@ -22,8 +22,11 @@ require('./common/check_controller_action')
 require('./common/new')
 //top
 require('./top')
-//brainstormingのedit画面
+//brainstorming#edit
 require('./idea/brainstorming_channel')
+
+//word_gacha
+require('./idea/word_gacha')
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/04.source/ideash/app/javascript/packs/application.js
+++ b/04.source/ideash/app/javascript/packs/application.js
@@ -15,7 +15,7 @@ require("jquery-ui/ui/widgets/draggable")
 
 // fomantic-uiの読み込み
 import 'fomantic-ui-css/semantic.min.css'
-require('fomantic-ui-css/semantic')
+require('fomantic-ui-css/semantic.min')
 
 // 共有js
 // require('./common/check_controller_action')

--- a/04.source/ideash/app/javascript/packs/application.js
+++ b/04.source/ideash/app/javascript/packs/application.js
@@ -10,9 +10,12 @@ require("channels")
 
 require("jquery")
 require("jquery-ui")
+require("jquery-ui/ui/widgets/draggable")
+
 
 // fomantic-uiの読み込み
 import 'fomantic-ui-css/semantic.min.css'
+require('fomantic-ui-css/semantic')
 
 // 共有js
 // require('./common/check_controller_action')

--- a/04.source/ideash/app/javascript/packs/application.js
+++ b/04.source/ideash/app/javascript/packs/application.js
@@ -29,6 +29,8 @@ require('./user/account')
 require('./memo/memo')
 //brainstorming#edit
 require('./idea/brainstorming_channel')
+//mandarat#edit
+require('./idea/mandarat_channel')
 //word_gacha
 require('./idea/word_gacha')
 

--- a/04.source/ideash/app/javascript/packs/application.js
+++ b/04.source/ideash/app/javascript/packs/application.js
@@ -17,6 +17,7 @@ import 'fomantic-ui-css/semantic.min.css'
 // 共有js
 // require('./common/check_controller_action')
 require('./shared')
+require('./shared/_right_menu')
 
 // 各コントローラー用
 // idea新規作成画面

--- a/04.source/ideash/app/javascript/packs/application.js
+++ b/04.source/ideash/app/javascript/packs/application.js
@@ -15,7 +15,7 @@ require("jquery-ui")
 import 'fomantic-ui-css/semantic.min.css'
 
 // 共有js
-require('./common/check_controller_action')
+// require('./common/check_controller_action')
 require('./shared')
 
 // 各コントローラー用
@@ -23,6 +23,8 @@ require('./shared')
 require('./common/new')
 //top
 require('./top')
+//user#edit
+require('./user/account')
 //memo#memo
 require('./memo/memo')
 //brainstorming#edit

--- a/04.source/ideash/app/javascript/packs/common/check_controller_action.js
+++ b/04.source/ideash/app/javascript/packs/common/check_controller_action.js
@@ -2,8 +2,5 @@ export const checkControllerAction = function ( permit_controllers, permit_actio
     let $body = $('body')
     const controller = $body.data('controller')
     const action = $body.data('action')
-    console.log(`${controller}#${action}`)
-    const rt = permit_controllers.indexOf(controller) >= 0 && permit_actions.indexOf(action) >= 0
-    if(rt)console.log(`active ${permit_controllers} # ${permit_actions}`)
     return (permit_controllers.indexOf(controller) >= 0 && permit_actions.indexOf(action) >= 0);
 }

--- a/04.source/ideash/app/javascript/packs/common/check_controller_action.js
+++ b/04.source/ideash/app/javascript/packs/common/check_controller_action.js
@@ -2,6 +2,7 @@ export const checkControllerAction = function ( permit_controllers, permit_actio
     let $body = $('body')
     const controller = $body.data('controller')
     const action = $body.data('action')
+    console.log(`${controller}#${action}`)
     const rt = permit_controllers.indexOf(controller) >= 0 && permit_actions.indexOf(action) >= 0
     if(rt)console.log(`active ${permit_controllers} # ${permit_actions}`)
     return (permit_controllers.indexOf(controller) >= 0 && permit_actions.indexOf(action) >= 0);

--- a/04.source/ideash/app/javascript/packs/common/check_controller_action.js
+++ b/04.source/ideash/app/javascript/packs/common/check_controller_action.js
@@ -1,0 +1,6 @@
+export const checkControllerAction = function ( permit_controllers, permit_actions) {
+    let $body = $('body')
+    const controller = $body.data('controller')
+    const action = $body.data('action')
+    return (permit_controllers.indexOf(controller) >= 0 && permit_actions.indexOf(action) >= 0)
+}

--- a/04.source/ideash/app/javascript/packs/common/check_controller_action.js
+++ b/04.source/ideash/app/javascript/packs/common/check_controller_action.js
@@ -2,5 +2,7 @@ export const checkControllerAction = function ( permit_controllers, permit_actio
     let $body = $('body')
     const controller = $body.data('controller')
     const action = $body.data('action')
-    return (permit_controllers.indexOf(controller) >= 0 && permit_actions.indexOf(action) >= 0)
+    const rt = permit_controllers.indexOf(controller) >= 0 && permit_actions.indexOf(action) >= 0
+    if(rt)console.log(`active ${permit_controllers} # ${permit_actions}`)
+    return (permit_controllers.indexOf(controller) >= 0 && permit_actions.indexOf(action) >= 0);
 }

--- a/04.source/ideash/app/javascript/packs/common/new.js
+++ b/04.source/ideash/app/javascript/packs/common/new.js
@@ -2,7 +2,6 @@ import {checkControllerAction} from "./check_controller_action";
 
 $(document).on("turbolinks:load", function () {
     if (checkControllerAction(['brainstorming','mandarat'],['new'])) {
-        console.log("active")
         // NOTE: テーマを入力しないとアイデアを作成できないようにする処理
         $("input[id='theme']").blur(function () {
             if (!$(this).val().match(/\S/g)) {

--- a/04.source/ideash/app/javascript/packs/common/new.js
+++ b/04.source/ideash/app/javascript/packs/common/new.js
@@ -1,28 +1,33 @@
-// NOTE: テーマを入力しないとアイデアを作成できないようにする処理
+import {checkControllerAction} from "./check_controller_action";
+
 $(document).on("turbolinks:load", function () {
-    $("input[id='theme']").blur(function () {
-        if (!$(this).val().match(/\S/g)) {
-            $(this).css('background-color', '#FEF4F8');
-            $('#start_button').prop('disabled', true)
-        } else {
-            $(this).css('background-color', '#FaFEFF');
+    if (checkControllerAction(['brainstorming','mandarat'],['new'])) {
+        console.log("active")
+        // NOTE: テーマを入力しないとアイデアを作成できないようにする処理
+        $("input[id='theme']").blur(function () {
+            if (!$(this).val().match(/\S/g)) {
+                $(this).css('background-color', '#FEF4F8');
+                $('#start_button').prop('disabled', true)
+            } else {
+                $(this).css('background-color', '#FaFEFF');
+                $('#start_button').prop('disabled', false)
+            }
+        });
+
+        $('#theme').keydown(function (event) {
             $('#start_button').prop('disabled', false)
-        }
-    });
+        })
 
-    $('#theme').keydown(function (event) {
-        $('#start_button').prop('disabled', false)
-    })
-
-    $('#is_unlimited').click(function () {
-        if (this.checked) {
-            $('#process1').prop('disabled', true)
-            $('#process2').prop('disabled', true)
-            $('#process3').prop('disabled', true)
-        } else {
-            $('#process1').prop('disabled', false)
-            $('#process2').prop('disabled', false)
-            $('#process3').prop('disabled', false)
-        }
-    });
+        $('#is_unlimited').click(function () {
+            if (this.checked) {
+                $('#process1').prop('disabled', true)
+                $('#process2').prop('disabled', true)
+                $('#process3').prop('disabled', true)
+            } else {
+                $('#process1').prop('disabled', false)
+                $('#process2').prop('disabled', false)
+                $('#process3').prop('disabled', false)
+            }
+        });
+    }
 });

--- a/04.source/ideash/app/javascript/packs/common/new.js
+++ b/04.source/ideash/app/javascript/packs/common/new.js
@@ -1,32 +1,31 @@
 import {checkControllerAction} from "./check_controller_action";
 
 $(document).on("turbolinks:load", function () {
-    if (checkControllerAction(['brainstorming','mandarat'],['new'])) {
-        // NOTE: テーマを入力しないとアイデアを作成できないようにする処理
-        $("input[id='theme']").blur(function () {
-            if (!$(this).val().match(/\S/g)) {
-                $(this).css('background-color', '#FEF4F8');
-                $('#start_button').prop('disabled', true)
-            } else {
-                $(this).css('background-color', '#FaFEFF');
-                $('#start_button').prop('disabled', false)
-            }
-        });
-
-        $('#theme').keydown(function (event) {
+    if (!checkControllerAction(['brainstorming', 'mandarat'], ['new'])) return
+    // NOTE: テーマを入力しないとアイデアを作成できないようにする処理
+    $("input[id='theme']").blur(function () {
+        if (!$(this).val().match(/\S/g)) {
+            $(this).css('background-color', '#FEF4F8');
+            $('#start_button').prop('disabled', true)
+        } else {
+            $(this).css('background-color', '#FaFEFF');
             $('#start_button').prop('disabled', false)
-        })
+        }
+    });
 
-        $('#is_unlimited').click(function () {
-            if (this.checked) {
-                $('#process1').prop('disabled', true)
-                $('#process2').prop('disabled', true)
-                $('#process3').prop('disabled', true)
-            } else {
-                $('#process1').prop('disabled', false)
-                $('#process2').prop('disabled', false)
-                $('#process3').prop('disabled', false)
-            }
-        });
-    }
+    $('#theme').keydown(function (event) {
+        $('#start_button').prop('disabled', false)
+    })
+
+    $('#is_unlimited').click(function () {
+        if (this.checked) {
+            $('#process1').prop('disabled', true)
+            $('#process2').prop('disabled', true)
+            $('#process3').prop('disabled', true)
+        } else {
+            $('#process1').prop('disabled', false)
+            $('#process2').prop('disabled', false)
+            $('#process3').prop('disabled', false)
+        }
+    });
 });

--- a/04.source/ideash/app/javascript/packs/idea/brainstorming_channel.js
+++ b/04.source/ideash/app/javascript/packs/idea/brainstorming_channel.js
@@ -1,8 +1,12 @@
 import consumer from "../../channels/consumer"
+import {checkControllerAction} from "../common/check_controller_action";
 
 require('fomantic-ui-css/semantic.min')
 require('jquery/src/jquery')
-$(function () {
+$(document).on("turbolinks:load", function () {
+    if(!checkControllerAction(['brainstorming'],['edit'])){
+        return
+    }
     if ($('.websocket').length > 0) {
         consumer.task = consumer.subscriptions.create({
             channel: 'IdeaChannel',

--- a/04.source/ideash/app/javascript/packs/idea/brainstorming_channel.js
+++ b/04.source/ideash/app/javascript/packs/idea/brainstorming_channel.js
@@ -1,8 +1,7 @@
 import consumer from "../../channels/consumer"
 import {checkControllerAction} from "../common/check_controller_action";
 
-require('fomantic-ui-css/semantic.min')
-require('jquery/src/jquery')
+
 $(document).on("turbolinks:load", function () {
     if (!checkControllerAction(['brainstorming'], ['edit'])) return
 

--- a/04.source/ideash/app/javascript/packs/idea/brainstorming_channel.js
+++ b/04.source/ideash/app/javascript/packs/idea/brainstorming_channel.js
@@ -4,9 +4,8 @@ import {checkControllerAction} from "../common/check_controller_action";
 require('fomantic-ui-css/semantic.min')
 require('jquery/src/jquery')
 $(document).on("turbolinks:load", function () {
-    if(!checkControllerAction(['brainstorming'],['edit'])){
-        return
-    }
+    if (!checkControllerAction(['brainstorming'], ['edit'])) return
+
     if ($('.websocket').length > 0) {
         consumer.task = consumer.subscriptions.create({
             channel: 'IdeaChannel',

--- a/04.source/ideash/app/javascript/packs/idea/mandarat_channel.js
+++ b/04.source/ideash/app/javascript/packs/idea/mandarat_channel.js
@@ -1,8 +1,6 @@
 import consumer from "../../channels/consumer"
 import {checkControllerAction} from "../common/check_controller_action";
 
-require('fomantic-ui-css/semantic.min');
-
 $(document).on("turbolinks:load", function () {
     if (!checkControllerAction(['mandarat'], ['edit'])) return
     if ($('.websocket-mandarat').length > 0) {

--- a/04.source/ideash/app/javascript/packs/idea/mandarat_channel.js
+++ b/04.source/ideash/app/javascript/packs/idea/mandarat_channel.js
@@ -1,7 +1,10 @@
 import consumer from "../../channels/consumer"
+import {checkControllerAction} from "../common/check_controller_action";
+
 require('fomantic-ui-css/semantic.min');
 
 $(document).on("turbolinks:load", function () {
+    if (!checkControllerAction(['mandarat'], ['edit'])) return
     if ($('.websocket-mandarat').length > 0) {
         // const chatChannel = consumer.subscriptions.create({
         consumer.task = consumer.subscriptions.create({

--- a/04.source/ideash/app/javascript/packs/idea/word_gacha.js
+++ b/04.source/ideash/app/javascript/packs/idea/word_gacha.js
@@ -1,5 +1,4 @@
 import {checkControllerAction} from "../common/check_controller_action";
-require('fomantic-ui-css/semantic.min')
 
 $(document).on("turbolinks:load", function () {
     checkControllerAction(['word_gacha'],['edit'])

--- a/04.source/ideash/app/javascript/packs/idea/word_gacha.js
+++ b/04.source/ideash/app/javascript/packs/idea/word_gacha.js
@@ -1,7 +1,9 @@
-$(document).on("turbolinks:load", function () {
-    require('fomantic-ui-css/semantic.min')
-    $('.ui.dropdown').dropdown()
+import {checkControllerAction} from "../common/check_controller_action";
+require('fomantic-ui-css/semantic.min')
 
+$(document).on("turbolinks:load", function () {
+    checkControllerAction(['word_gacha'],['edit'])
+    $('.ui.dropdown').dropdown()
     //ガチャを回す
     $('#turn-gacha-button').on('click', turnbtn);
     let gacha_num = 0;

--- a/04.source/ideash/app/javascript/packs/memo/memo.js
+++ b/04.source/ideash/app/javascript/packs/memo/memo.js
@@ -1,57 +1,62 @@
+import {checkControllerAction} from "../common/check_controller_action";
+
 require('fomantic-ui-css/semantic.min');
+document.addEventListener("turbolinks:load", function () {
+    if (!checkControllerAction(['memo'], ['new', 'edit'])) return;
 
-$('.message .close')
-    .on('click', function () {
-        $(this)
-            .closest('.message')
-            .transition('fade')
-        ;
+    $('.message .close')
+        .on('click', function () {
+            $(this)
+                .closest('.message')
+                .transition('fade')
+            ;
+        })
+    ;
+
+
+    $("#memo-submit").click(function () {
+        if (!$('#memo-title').val().match(/\S/g) || !$('#memo-content').val().match(/\S/g)) {
+            $('body')
+                .toast({
+                    title: 'CAUTION',
+                    message: 'スペース、空欄での入力はできません',
+                    showProgress: 'bottom',
+                    classProgress: 'red'
+                });
+            return false;
+        }
+    });
+
+    $(function () {
+        memo_save()
     })
-;
 
-
-$("#memo-submit").click(function(){
-    if(!$('#memo-title').val().match(/\S/g) || !$('#memo-content').val().match(/\S/g)){
-        $('body')
-            .toast({
-                title: 'CAUTION',
-                message: 'スペース、空欄での入力はできません',
-                showProgress: 'bottom',
-                classProgress: 'red'
-            });
-        return false;
+    function memo_save() {
+        let info_message = $('#memo_save').val();
+        if (info_message === 'success') {
+            $('body')
+                .toast({
+                    title: 'SUCCESS',
+                    message: 'メモを保存しました。',
+                    showProgress: 'bottom',
+                    classProgress: 'blue'
+                });
+        } else if (info_message === 'update') {
+            $('body')
+                .toast({
+                    title: 'SUCCESS',
+                    message: 'メモを更新しました。',
+                    showProgress: 'bottom',
+                    classProgress: 'green'
+                });
+        } else if (info_message === 'fail') {
+            $('body')
+                .toast({
+                    title: 'CAUTION',
+                    message: 'メモの保存に失敗しました。再度やり直してください。',
+                    showProgress: 'bottom',
+                    classProgress: 'red'
+                });
+        }
     }
 });
-
-$(function () {
-    memo_save()
-})
-
-function memo_save() {
-    let info_message = $('#memo_save').val();
-    if(info_message === 'success'){
-        $('body')
-            .toast({
-                title: 'SUCCESS',
-                message: 'メモを保存しました。',
-                showProgress: 'bottom',
-                classProgress: 'blue'
-            });
-    }else if (info_message === 'update'){
-        $('body')
-            .toast({
-                title: 'SUCCESS',
-                message: 'メモを更新しました。',
-                showProgress: 'bottom',
-                classProgress: 'green'
-            });
-    }else if (info_message === 'fail'){
-        $('body')
-            .toast({
-                title: 'CAUTION',
-                message: 'メモの保存に失敗しました。再度やり直してください。',
-                showProgress: 'bottom',
-                classProgress: 'red'
-            });
-    }
-}

--- a/04.source/ideash/app/javascript/packs/memo/memo.js
+++ b/04.source/ideash/app/javascript/packs/memo/memo.js
@@ -1,6 +1,5 @@
 import {checkControllerAction} from "../common/check_controller_action";
 
-require('fomantic-ui-css/semantic.min');
 document.addEventListener("turbolinks:load", function () {
     if (!checkControllerAction(['memo'], ['new', 'edit'])) return;
 

--- a/04.source/ideash/app/javascript/packs/memo/memo_edit.js
+++ b/04.source/ideash/app/javascript/packs/memo/memo_edit.js
@@ -1,5 +1,3 @@
-require('fomantic-ui-css/semantic.min');
-
 $("input[id='memo-title'],[id='memo-content']").blur(function(){
     if(!$(this).val().match(/\S/g)){
         $(this).css("background-color", "#FEF4F8");

--- a/04.source/ideash/app/javascript/packs/shared.js
+++ b/04.source/ideash/app/javascript/packs/shared.js
@@ -1,5 +1,3 @@
-require('fomantic-ui-css/semantic.min');
-
 document.addEventListener("turbolinks:load", function () {
     //読み込み時の表示
     $('.fade_object').fadeIn(500);

--- a/04.source/ideash/app/javascript/packs/shared/_debug_menu.js
+++ b/04.source/ideash/app/javascript/packs/shared/_debug_menu.js
@@ -1,5 +1,4 @@
 $(document).on("turbolinks:load", function () {
-    require('fomantic-ui-css/semantic.min')
     $('body').keydown(function (e) {
         // alert(JSON.stringify(e.keyCode))
         // Shift + d を入力するとデバッグメニューを表示する

--- a/04.source/ideash/app/javascript/packs/shared/_debug_menu.js
+++ b/04.source/ideash/app/javascript/packs/shared/_debug_menu.js
@@ -1,4 +1,5 @@
 $(document).on("turbolinks:load", function () {
+    require('fomantic-ui-css/semantic.min')
     $('body').keydown(function (e) {
         // alert(JSON.stringify(e.keyCode))
         // Shift + d を入力するとデバッグメニューを表示する

--- a/04.source/ideash/app/javascript/packs/shared/_right_menu.js
+++ b/04.source/ideash/app/javascript/packs/shared/_right_menu.js
@@ -1,12 +1,14 @@
-$(function () {
-    require('fomantic-ui-css/semantic.min');
-    require('jquery-ui/ui/widgets/draggable')
+import {checkControllerAction} from "../common/check_controller_action";
 
-    $(function () {
-        $('.chat').draggable({
-            containment: '#wrap',
-            scroll: false
-        });
+require('fomantic-ui-css/semantic.min');
+require('jquery-ui/ui/widgets/draggable')
+
+$(document).on("turbolinks:load", function () {
+    if (!checkControllerAction(['brainstorming', 'mandarat'], ['edit'])) return
+
+    $('.chat').draggable({
+        containment: '#wrap',
+        scroll: false
     });
 
     // let clipboard = new Clipboard('.copy');

--- a/04.source/ideash/app/javascript/packs/shared/_right_menu.js
+++ b/04.source/ideash/app/javascript/packs/shared/_right_menu.js
@@ -1,8 +1,5 @@
 import {checkControllerAction} from "../common/check_controller_action";
 
-require('fomantic-ui-css/semantic.min');
-require('jquery-ui/ui/widgets/draggable')
-
 $(document).on("turbolinks:load", function () {
     if (!checkControllerAction(['brainstorming', 'mandarat'], ['edit'])) return
 
@@ -11,7 +8,6 @@ $(document).on("turbolinks:load", function () {
         scroll: false
     });
 
-    // let clipboard = new Clipboard('.copy');
     let timerId = setInterval(showClock2, 1000);
     showClock2(timerId)
 

--- a/04.source/ideash/app/javascript/packs/top.js
+++ b/04.source/ideash/app/javascript/packs/top.js
@@ -1,5 +1,7 @@
 require('fomantic-ui-css/semantic.min');
+import {checkControllerAction} from "./common/check_controller_action";
 
 $(document).on("turbolinks:load", function () {
+    if (!checkControllerAction(['top'], ['index'])) return
     $('.accordion').accordion()
 });

--- a/04.source/ideash/app/javascript/packs/top.js
+++ b/04.source/ideash/app/javascript/packs/top.js
@@ -1,4 +1,3 @@
-require('fomantic-ui-css/semantic.min');
 import {checkControllerAction} from "./common/check_controller_action";
 
 $(document).on("turbolinks:load", function () {

--- a/04.source/ideash/app/javascript/packs/user/account.js
+++ b/04.source/ideash/app/javascript/packs/user/account.js
@@ -1,6 +1,5 @@
 import {checkControllerAction} from "../common/check_controller_action";
 
-require('fomantic-ui-css/semantic.min');
 $(document).on("turbolinks:load", function () {
     if (!checkControllerAction(['registrations'],['profile_edit'])) return;
     toast_updated();

--- a/04.source/ideash/app/javascript/packs/user/account.js
+++ b/04.source/ideash/app/javascript/packs/user/account.js
@@ -1,29 +1,32 @@
-require('fomantic-ui-css/semantic.min');
-$(function () {
-        toast_updated()
-    }
-)
+import {checkControllerAction} from "../common/check_controller_action";
 
-function toast_updated() {
-    let is_updated = $('#is_updated').val();
-    // 初回時は空白になるのでそのまま返す
-    if (is_updated === "") return;
-    let user_name = $('#account_input').val();
-    if (is_updated) {
-        $('body')
-            .toast({
-                title: 'SUCCESS',
-                message: user_name + 'に更新しました',
-                showProgress: 'bottom',
-                classProgress: 'blue'
-            });
-    } else {
-        $('body')
-            .toast({
-                title: 'FAILURE',
-                message: '更新に失敗しました。',
-                showProgress: 'bottom',
-                classProgress: 'red'
-            });
+require('fomantic-ui-css/semantic.min');
+$(document).on("turbolinks:load", function () {
+    if (!checkControllerAction(['registrations'],['profile_edit'])) return;
+    toast_updated();
+
+    function toast_updated() {
+        let is_updated = $('#is_updated').val();
+        // 初回時は空白になるのでそのまま返す
+        if (is_updated === "") return;
+        let user_name = $('#account_input').val();
+        if (is_updated) {
+            $('body')
+                .toast({
+                    title: 'SUCCESS',
+                    message: user_name + 'に更新しました',
+                    showProgress: 'bottom',
+                    classProgress: 'blue'
+                });
+        } else {
+            $('body')
+                .toast({
+                    title: 'FAILURE',
+                    message: '更新に失敗しました。',
+                    showProgress: 'bottom',
+                    classProgress: 'red'
+                });
+        }
     }
-}
+});
+

--- a/04.source/ideash/app/javascript/packs/user/account.js
+++ b/04.source/ideash/app/javascript/packs/user/account.js
@@ -1,9 +1,8 @@
 import {checkControllerAction} from "../common/check_controller_action";
 
 $(document).on("turbolinks:load", function () {
-    if (!checkControllerAction(['registrations'],['profile_edit'])) return;
+    if (!checkControllerAction(['registrations'],['profile_edit','profile_update'])) return;
     toast_updated();
-
     function toast_updated() {
         let is_updated = $('#is_updated').val();
         // 初回時は空白になるのでそのまま返す

--- a/04.source/ideash/app/views/brainstorming/edit.html.erb
+++ b/04.source/ideash/app/views/brainstorming/edit.html.erb
@@ -1,5 +1,3 @@
-<%= javascript_pack_tag "idea/brainstorming_channel" %>
-
 <span class="websocket" id="idea_logs" data-idea_id="<%= @idea.id %>"></span>
 <div id="edit_body">
   <button class="ui black basic mini button change_process" onclick="changeBtn()">画面切り替え</button>アイデア出しとグルーピングの画面が切り替わります

--- a/04.source/ideash/app/views/brainstorming/new.html.erb
+++ b/04.source/ideash/app/views/brainstorming/new.html.erb
@@ -1,4 +1,3 @@
-<%= javascript_pack_tag 'common/new' %>
 <div class="tech_about_body">
   <div class="ui segments block-tech-about">
     <div class="ui segment">

--- a/04.source/ideash/app/views/ideas/account.html.erb
+++ b/04.source/ideash/app/views/ideas/account.html.erb
@@ -1,4 +1,3 @@
-<%= javascript_pack_tag 'user/account' %>
 <input type=hidden id="is_updated" value=<%= @is_updated %>>
 
 <%= form_for current_user, url: {action: 'profile_update'} do |f| %>

--- a/04.source/ideash/app/views/layouts/application.html.erb
+++ b/04.source/ideash/app/views/layouts/application.html.erb
@@ -38,7 +38,7 @@
   <%= favicon_link_tag('icon.svg') %>
 
 </head>
-<body class="<%= controller_name %> <%= action_name %>">
+<body data-controller="<%= controller_name %>" data-action="<%= action_name %>">
 <% if Rails.env.development? %>
   <%= render :partial => 'shared/debug_menu' %>
 <% end %>

--- a/04.source/ideash/app/views/layouts/head_left_layout.html.erb
+++ b/04.source/ideash/app/views/layouts/head_left_layout.html.erb
@@ -28,7 +28,6 @@
   <%= csp_meta_tag %>
   <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
   <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
-  <%= javascript_pack_tag 'shared', 'data-turbolinks-track': 'reload' %>
   <!-- fomantic-ui -->
   <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.7/dist/semantic.min.css">
 

--- a/04.source/ideash/app/views/layouts/head_left_layout.html.erb
+++ b/04.source/ideash/app/views/layouts/head_left_layout.html.erb
@@ -39,7 +39,7 @@
   <%= favicon_link_tag('icon.svg') %>
 
 </head>
-<body class="<%= controller_name %> <%= action_name %>">
+<body data-controller="<%= controller_name %>" data-action="<%= action_name %>">
 <% if Rails.env.development? %>
   <%= render :partial => 'shared/debug_menu' %>
 <% end %>

--- a/04.source/ideash/app/views/mandarat/edit.html.erb
+++ b/04.source/ideash/app/views/mandarat/edit.html.erb
@@ -1,4 +1,3 @@
-<%= javascript_pack_tag "idea/mandarat_channel" %>
 <span class="websocket-mandarat" id="idea_logs" data-idea_id="<%= @idea.id %>"></span>
 
 <div id="process_2"><%= render :partial => 'mandarat/process_2', locals: {idea: @idea, idea_logs: @idea_logs} %></div>

--- a/04.source/ideash/app/views/mandarat/new.html.erb
+++ b/04.source/ideash/app/views/mandarat/new.html.erb
@@ -1,4 +1,3 @@
-<%= javascript_pack_tag 'common/new' %>
 <div class="tech_about_body">
   <div class="ui segments block-tech-about">
     <div class="ui segment">

--- a/04.source/ideash/app/views/memo/edit.html.erb
+++ b/04.source/ideash/app/views/memo/edit.html.erb
@@ -1,5 +1,3 @@
-<%= javascript_pack_tag 'memo/memo' %>
-
 <%# 右部のメモ一覧 %>
 <div class="ui right fixed vertical menu block-edit-sidebar memo_sidebar">
   <%= render partial: 'shared/memomenu', collection: @user_memo.reverse, as: "memo" %>

--- a/04.source/ideash/app/views/memo/new.html.erb
+++ b/04.source/ideash/app/views/memo/new.html.erb
@@ -1,4 +1,3 @@
-<%= javascript_pack_tag 'memo/memo' %>
 <%# 右部のメモ一覧 %>
 <div class="ui right fixed vertical menu block-edit-sidebar memo_sidebar">
   <%= render partial: 'shared/memomenu', collection: @user_memo.reverse, as: "memo" %>

--- a/04.source/ideash/app/views/shared/_debug_menu.html.erb
+++ b/04.source/ideash/app/views/shared/_debug_menu.html.erb
@@ -1,43 +1,54 @@
 <!-- デバッグメニュー -->
 <%# debug_menuをproduction環境で見せたくないためapplication.jsには書かない %>
-<%=javascript_pack_tag 'shared/_debug_menu' %>
+<%= javascript_pack_tag 'shared/_debug_menu' %>
 <div class="ui modal" id="debug-modal-window">
   <div class="ui segments">
     <div class="ui segment">
       <div class="ui header">デバッグメニュー</div>
     </div>
     <div class="ui segment">
-      <div class="ui grid">
-        <div class="ui list">
-          <div class="ui label">STATUS INFO</div>
-          <% if user_signed_in? %>
-            <div class="item">
-              <i class="users icon"></i>
-              USER-ID:<%= current_user.id %>
-            </div>
-            <div class="item">
-              <i class="users icon"></i>
-              USER-NAME:<%= current_user.user_name %>
-            </div>
-            <div class="item">
-              <i class="mail icon"></i>
-              EMAIL:<%= current_user.email %>
-            </div>
-          <% else %>
-            未ログイン
-          <% end %>
+      <div class="ui list">
+        <div class="ui label">STATUS INFO</div>
+        <% if user_signed_in? %>
+          <div class="item">
+            <i class="users icon"></i>
+            USER-ID:<%= current_user.id %>
+          </div>
+          <div class="item">
+            <i class="users icon"></i>
+            USER-NAME:<%= current_user.user_name %>
+          </div>
+          <div class="item">
+            <i class="mail icon"></i>
+            EMAIL:<%= current_user.email %>
+          </div>
+        <% else %>
+          未ログイン
+        <% end %>
+      </div>
+    </div>
+    <div class="ui segment">
+      <div class="ui list">
+        <div class="ui label">RAILS INFO</div>
+        <div class="item">
+          <i class="terminal icon"></i>
+          CONTROLLER: <%= controller_name %>
+        </div>
+        <div class="item">
+          <i class="code icon"></i>
+          ACTION: <%= action_name %>
         </div>
       </div>
     </div>
-  </div>
-  <div class="ui segment">
-    <div class="ui actions">
-      <% if user_signed_in? %>
-        <%= link_to "サインアウト", account_signout_path, class: 'ui red button' %>
-      <% else %>
-        <%= link_to "サインイン", account_signin_path, class: 'ui blue button' %>
-        <%= link_to "サインアップ", account_signup_path, class: 'ui green button' %>
-      <% end %>
+    <div class="ui segment">
+      <div class="ui actions">
+        <% if user_signed_in? %>
+          <%= link_to "サインアウト", account_signout_path, class: 'ui red button' %>
+        <% else %>
+          <%= link_to "サインイン", account_signin_path, class: 'ui blue button' %>
+          <%= link_to "サインアップ", account_signup_path, class: 'ui green button' %>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>

--- a/04.source/ideash/app/views/shared/_debug_menu.html.erb
+++ b/04.source/ideash/app/views/shared/_debug_menu.html.erb
@@ -1,4 +1,5 @@
 <!-- デバッグメニュー -->
+<%# debug_menuをproduction環境で見せたくないためapplication.jsには書かない %>
 <%=javascript_pack_tag 'shared/_debug_menu' %>
 <div class="ui modal" id="debug-modal-window">
   <div class="ui segments">

--- a/04.source/ideash/app/views/shared/_right_menu.html.erb
+++ b/04.source/ideash/app/views/shared/_right_menu.html.erb
@@ -1,4 +1,3 @@
-<%= javascript_pack_tag 'shared/_right_menu' %>
 <input type="hidden" id="user_id" value="<%= current_user.id %>">
 <!-- 1 -->
 <div class="ui right fixed vertical menu block-edit-sidebar right_menu" id="right_menu">

--- a/04.source/ideash/app/views/top/index.html.erb
+++ b/04.source/ideash/app/views/top/index.html.erb
@@ -1,5 +1,4 @@
 <% content_for(:html_title) { 'top | Ideash' } %>
-<%= javascript_pack_tag 'top', 'data-turbolinks-track': 'reload' %>
 <!-- 背景緑部分 -->
 <div class="top" id="top_img">
   <div class="seg_1">

--- a/04.source/ideash/app/views/word_gacha/edit.html.erb
+++ b/04.source/ideash/app/views/word_gacha/edit.html.erb
@@ -1,4 +1,3 @@
-<%= javascript_pack_tag "idea/word_gacha" %>
 <div class="edit_body" id="edit_body">
   <div class="word-cards">
     <div class="to-previous-area">

--- a/04.source/ideash/config/routes.rb
+++ b/04.source/ideash/config/routes.rb
@@ -72,7 +72,7 @@ Rails.application.routes.draw do
     # INFO: アカウント設定
     # get 'account/edit' => 'users/registrations#edit'
     get 'account/edit', to: 'users/registrations#profile_edit', as: 'profile_edit'
-    patch 'profile_update', to: 'users/registrations#profile_update', as: 'profile_update'
+    patch 'account/edit', to: 'users/registrations#profile_update', as: 'profile_update'
   end
 
   # INFO: ユーザのホーム画面


### PR DESCRIPTION
#248 に対応することで
#293 の不具合も解消されました。
また、表には見えないだけで何度もjsが読み込まれていた不具合も解消されました。

ほぼ全てのjsを`application.js`経由で読み込むようにしています。
こうすることで`asset pipeline`を使う事ができ高速化も期待できます。
また、各jsに`require`文でfomantic-ui等を読み込む必要がなくなりました。

使い方は
`application.js`当該jsを読み込む`require`文を書く
各JSでchackControllerActionを読み込み引数に作動させる['controller名'...]['action名'...]
で許可させます。現状のものは対応したのでそれを参考にしてください