### PR TITLE
#324 履歴画面の調整, #285, #236, #268 左右メニュー周りの調整

### DIFF
--- a/04.source/ideash/app/assets/stylesheets/shared.scss
+++ b/04.source/ideash/app/assets/stylesheets/shared.scss
@@ -300,8 +300,6 @@ body {
     #right_icon_menu {
       display: flex;
       position: fixed;
-      top: 40px;
-      right: 0;
     }
   }
 

--- a/04.source/ideash/app/assets/stylesheets/shared.scss
+++ b/04.source/ideash/app/assets/stylesheets/shared.scss
@@ -242,6 +242,7 @@ body {
   #main_content {
     width: inherit;
     margin: 10px;
+    overflow-y: scroll;
   }
 
   .fade_object {

--- a/04.source/ideash/app/assets/stylesheets/shared.scss
+++ b/04.source/ideash/app/assets/stylesheets/shared.scss
@@ -150,17 +150,17 @@ body {
 }
 
 .chat {
-  //height: 50%;
+  height: 50%;
   //max-height: 40%;
   //display: grid !important;
   background-color: white !important;
   border: 1px solid !important;
   border-color: darkgray !important;
-  //position: absolute !important;
+  position: sticky !important;
 
   .chat-area {
-    height: 100%;
-    max-height: 100%;
+    //height: 100%;
+    max-height: 80%;
     padding-top: 1px;
     overflow-y: scroll;
   }

--- a/04.source/ideash/app/assets/stylesheets/shared.scss
+++ b/04.source/ideash/app/assets/stylesheets/shared.scss
@@ -222,24 +222,25 @@ body {
   display: flex;
 
   .left_menu {
+    overflow: hidden scroll;
     position: sticky;
     display: block;
     float: left;
     margin: 0;
   }
 
-  #left_menu {
-    min-width: 200px;
-    width: 15vh;
-    overflow: hidden scroll;
+  .left_menu::-webkit-scrollbar {
+    display: none;
   }
 
-  #left_menu::-webkit-scrollbar {
-    display: none;
+  #left_menu {
+    min-width: 200px;
+    width: 15vw;
   }
 
   #left_icon_menu {
     display: none;
+    width: 55px;
   }
 
   #main_content {
@@ -253,19 +254,28 @@ body {
   }
 
   .right_menu {
+    overflow: hidden scroll;
     position: sticky;
     display: flex;
     float: right;
     margin: 0;
   }
 
-  #right_menu {
-    width: 20vh;
+  .right_menu::-webkit-scrollbar {
+    display: none;
   }
+
+  #right_menu {
+    width: 15vw;
+    min-width: 150px;
+    max-width: 200px;
+  }
+
 
   #right_icon_menu {
     display: none;
     height: fit-content;
+    width: 50px;
     position: fixed;
     top: 40px;
     right: 0;

--- a/04.source/ideash/app/assets/stylesheets/shared.scss
+++ b/04.source/ideash/app/assets/stylesheets/shared.scss
@@ -49,10 +49,6 @@ body {
   margin-right: 185px;
 }
 
-/*left_menu*/
-.header_div {
-}
-
 .menu_icon {
   width: 40px;
 }
@@ -154,14 +150,13 @@ body {
 }
 
 .chat {
-  height: 50%;
+  //height: 50%;
   //max-height: 40%;
-  display: grid !important;
+  //display: grid !important;
   background-color: white !important;
   border: 1px solid !important;
   border-color: darkgray !important;
-  z-index: 0;
-
+  //position: absolute !important;
 
   .chat-area {
     height: 100%;
@@ -235,7 +230,7 @@ body {
 
   #left_menu {
     min-width: 200px;
-    width: 15vw;
+    max-width: 200px;
   }
 
   #left_icon_menu {

--- a/04.source/ideash/app/assets/stylesheets/shared.scss
+++ b/04.source/ideash/app/assets/stylesheets/shared.scss
@@ -155,36 +155,39 @@ body {
 
 .chat {
   height: 50%;
+  //max-height: 40%;
+  display: grid !important;
   background-color: white !important;
   border: 1px solid !important;
   border-color: darkgray !important;
   z-index: 0;
 
-}
 
-.chat-area {
-  //border: #1B1C1D 1px solid;
-  height: 90%;
-  padding-top: 1vh;
-  overflow: auto;
-}
+  .chat-area {
+    height: 100%;
+    max-height: 100%;
+    padding-top: 1px;
+    overflow-y: scroll;
+  }
 
-.chat-input {
-  width: 100%;
-  margin-top: 10px;
-  margin-bottom: 5px;
-}
+  .chat-input {
+    width: 100%;
+    margin-top: 10px;
+    margin-bottom: 5px;
+  }
 
-.chat_username {
-  margin: 5px !important;
-}
+  .chat_username {
+    margin: 5px !important;
+  }
 
-.chat_message {
-  display: block !important;
-  margin: 2px !important;
-  word-break: break-all;
-  left: 5%;
-  width: 85%;
+  .chat_message {
+    display: block !important;
+    margin: 2px !important;
+    word-break: break-all;
+    left: 5%;
+    width: 85%;
+  }
+
 }
 
 .memo-content {
@@ -232,7 +235,7 @@ body {
   }
 
   #left_menu::-webkit-scrollbar {
-    display:none;
+    display: none;
   }
 
   #left_icon_menu {
@@ -251,7 +254,7 @@ body {
 
   .right_menu {
     position: sticky;
-    display: block;
+    display: flex;
     float: right;
     margin: 0;
   }
@@ -263,6 +266,9 @@ body {
   #right_icon_menu {
     display: none;
     height: fit-content;
+    position: fixed;
+    top: 40px;
+    right: 0;
   }
 
 }
@@ -274,7 +280,7 @@ body {
     }
 
     #left_icon_menu {
-      display: block;
+      display: flex;
     }
 
     #right_menu {
@@ -282,7 +288,10 @@ body {
     }
 
     #right_icon_menu {
-      display: block;
+      display: flex;
+      position: fixed;
+      top: 40px;
+      right: 0;
     }
   }
 
@@ -297,25 +306,27 @@ img.icon_image {
 
 /*right_menu*/
 /*TODO: クラス名等が怪しいので調整を行う */
-.modal{
+.modal {
   display: none;
   height: 100vh;
   position: fixed;
   top: 0;
   width: 100%;
 }
-.modal__bg{
-  background: rgba(0,0,0,0.8);
+
+.modal__bg {
+  background: rgba(0, 0, 0, 0.8);
   height: 100vh;
   position: absolute;
   width: 100%;
 }
-.modal__content{
+
+.modal__content {
   background: #fff;
   left: 50%;
   padding: 40px;
   position: absolute;
   top: 50%;
-  transform: translate(-50%,-50%);
+  transform: translate(-50%, -50%);
   width: 60%;
 }

--- a/04.source/ideash/app/javascript/packs/shared/_right_menu.js
+++ b/04.source/ideash/app/javascript/packs/shared/_right_menu.js
@@ -4,8 +4,16 @@ $(document).on("turbolinks:load", function () {
     if (!checkControllerAction(['brainstorming', 'mandarat'], ['edit'])) return
 
     $('.chat').draggable({
-        containment: '#wrap',
-        scroll: false
+        appendTo: 'body',
+        containment: '#wrap', //ドラッグ可能範囲
+        scroll: false, //ドラッグ中のスクロールを拒否
+        helper: 'clone',
+        start: function(){ //hide original when showing clone
+            $(this).hide();
+        },
+        stop: function(){ //show original when hiding clone
+            $(this).show();
+        }
     });
 
     let timerId = setInterval(showClock2, 1000);
@@ -49,9 +57,9 @@ $(document).on("turbolinks:load", function () {
     $('#reset_chat_position').on('click', function () {
         $('.item').removeAttr('style')
     })
-    
+
     //modalの設定
-     if (location.href.match(/brainstorming/)) {
+    if (location.href.match(/brainstorming/)) {
         $('body').append('<div class="modal js-modal">\n' +
             '        <div class="modal__bg js-modal-close"></div>\n' +
             '        <div class="modal__content">\n' +

--- a/04.source/ideash/app/javascript/packs/shared/_right_menu.js
+++ b/04.source/ideash/app/javascript/packs/shared/_right_menu.js
@@ -3,18 +3,7 @@ import {checkControllerAction} from "../common/check_controller_action";
 $(document).on("turbolinks:load", function () {
     if (!checkControllerAction(['brainstorming', 'mandarat'], ['edit'])) return
 
-    $('.chat').draggable({
-        appendTo: 'body',
-        containment: '#wrap', //ドラッグ可能範囲
-        scroll: false, //ドラッグ中のスクロールを拒否
-        helper: 'clone',
-        start: function(){ //hide original when showing clone
-            $(this).hide();
-        },
-        stop: function(){ //show original when hiding clone
-            $(this).show();
-        }
-    });
+    // $('.chat').draggable();
 
     let timerId = setInterval(showClock2, 1000);
     showClock2(timerId)

--- a/04.source/ideash/app/views/ideas/history.html.erb
+++ b/04.source/ideash/app/views/ideas/history.html.erb
@@ -1,6 +1,6 @@
 <%# TODO: サムネイル表示に対応する %>
 <div class="ui container">
-  <table class="ui celled striped table">
+  <table class="ui selectable celled striped table">
     <thead>
     <tr>
       <th colspan="3">
@@ -13,18 +13,14 @@
       <% if Rails.env.test? %>
         <tr class="feature-test-history">
       <% else %>
-        <tr>
+        <tr onclick="location.href='<%= "#{@categories[idea.idea_category_id]['manage_name']}/edit/#{idea.id}" %>'">
       <% end %>
-      <td>
-        <%= link_to ("#{@categories[idea.idea_category_id]['manage_name']}/edit/#{idea.id}"), local: true, data: {"turbolinks" => false} do %>
-          <%= "#{@categories[idea.idea_category_id]["idea_category_name"]}" %>
-        <% end %>
+      <td class='collapsing'>
+        <i class="folder icon"></i>
+        <%= "#{@categories[idea.idea_category_id]["idea_category_name"]}" %>
       </td>
-      <td class="collapsing">
-        <%= link_to ("#{@categories[idea.idea_category_id]['manage_name']}/edit/#{idea.id}"), local: true, data: {"turbolinks" => false} do %>
-          <i class="folder icon"></i>
-          <%= idea.idea_name.truncate(20, omission: '...') %>
-        <% end %>
+      <td>
+        <%= idea.idea_name.truncate(20, omission: '...') %>
       </td>
       </tr>
     <% end %>


### PR DESCRIPTION
#324 履歴画面を調整しカーソルをホバーした行がハイライトするようにしました
#236 rightメニューの縦幅を100%に変更しました
#268 履歴画面で文字単位から行単位でクリックできるように変更しました
#285 rightメニューの横幅がvwを参照していたものを固定値に変更しました
また、左右のメニューが崩れないようにleft_menu, right_menu, main_contentをoverflow_scrollに変更しました
伴ってdraggableのバグでドラッグしたchat欄がmain_contentの裏に隠れる不具合が発生したため一時的にdraggableを解除しました