### PR TITLE
#334 #344 チャット欄周りの修正

### DIFF
--- a/04.source/ideash/app/assets/stylesheets/shared.scss
+++ b/04.source/ideash/app/assets/stylesheets/shared.scss
@@ -156,6 +156,7 @@ body {
   border: 1px solid !important;
   border-color: darkgray !important;
   position: fixed !important;
+  padding-bottom: 10px;
   bottom: 0;
   right: 0;
   z-index: 30000;
@@ -170,7 +171,7 @@ body {
     height: 100%;
     max-height: 80%;
     padding-top: 1px;
-    overflow: scroll;
+    overflow-y: scroll;
   }
 
   .chat_username {

--- a/04.source/ideash/app/assets/stylesheets/shared.scss
+++ b/04.source/ideash/app/assets/stylesheets/shared.scss
@@ -161,6 +161,9 @@ body {
   right: 0;
   z-index: 30000;
 
+  .header-text{
+    cursor: move;
+  }
   .chat-input {
     width: 100%;
     margin-top: 10px;

--- a/04.source/ideash/app/assets/stylesheets/shared.scss
+++ b/04.source/ideash/app/assets/stylesheets/shared.scss
@@ -150,20 +150,15 @@ body {
 }
 
 .chat {
-  height: 50%;
-  //max-height: 40%;
-  //display: grid !important;
+  height: 300px;
+  width: 200px;
   background-color: white !important;
   border: 1px solid !important;
   border-color: darkgray !important;
-  position: sticky !important;
-
-  .chat-area {
-    //height: 100%;
-    max-height: 80%;
-    padding-top: 1px;
-    overflow-y: scroll;
-  }
+  position: fixed !important;
+  bottom: 0;
+  right: 0;
+  z-index: 30000;
 
   .chat-input {
     width: 100%;
@@ -171,10 +166,17 @@ body {
     margin-bottom: 5px;
   }
 
+  .chat-area {
+    height: 100%;
+    max-height: 80%;
+    padding-top: 1px;
+    overflow: scroll;
+  }
+
   .chat_username {
     margin: 5px !important;
   }
-
+  //
   .chat_message {
     display: block !important;
     margin: 2px !important;

--- a/04.source/ideash/app/javascript/packs/application.js
+++ b/04.source/ideash/app/javascript/packs/application.js
@@ -10,7 +10,9 @@ require("channels")
 
 require("jquery")
 require("jquery-ui")
+require("jquery-ui/themes/base/all.css")
 require("jquery-ui/ui/widgets/draggable")
+require("jquery-ui/ui/widgets/resizable")
 
 
 // fomantic-uiの読み込み

--- a/04.source/ideash/app/javascript/packs/shared/_right_menu.js
+++ b/04.source/ideash/app/javascript/packs/shared/_right_menu.js
@@ -3,7 +3,7 @@ import {checkControllerAction} from "../common/check_controller_action";
 $(document).on("turbolinks:load", function () {
     if (!checkControllerAction(['brainstorming', 'mandarat'], ['edit'])) return
 
-    // $('.chat').draggable();
+    $('.chat').draggable();
 
     let timerId = setInterval(showClock2, 1000);
     showClock2(timerId)

--- a/04.source/ideash/app/javascript/packs/shared/_right_menu.js
+++ b/04.source/ideash/app/javascript/packs/shared/_right_menu.js
@@ -5,6 +5,8 @@ $(document).on("turbolinks:load", function () {
 
     $('.chat').draggable({
         containment: "#wrap",
+        handle: ".header-text",
+        opacity: 0.5,
     });
 
     let timerId = setInterval(showClock2, 1000);

--- a/04.source/ideash/app/javascript/packs/shared/_right_menu.js
+++ b/04.source/ideash/app/javascript/packs/shared/_right_menu.js
@@ -2,20 +2,38 @@ import {checkControllerAction} from "../common/check_controller_action";
 
 $(document).on("turbolinks:load", function () {
     if (!checkControllerAction(['brainstorming', 'mandarat'], ['edit'])) return
-    // let $chat = $('.chat')
+
+    //チャット欄の設定
     let $chat = $('.chat')
+    let chat_original_position
+    let chat_original_size
     $chat
         .draggable({
             containment: "#wrap",
             handle: ".header-text",
             opacity: 0.5,
+            start: function (event, ui) {
+                chat_original_position = chat_original_position ?? ui.position;
+            }
         })
         .resizable({
             minHeight: 300,
-            minWidth:150,
-            handles: "e,s,w,se,sw"
+            minWidth: 150,
+            handles: "e,s,w,se,sw,ne,nw",
+            start: function (event, ui) {
+                chat_original_size = chat_original_size ?? ui.originalSize
+            }
         });
-    console.log($chat.resizable)
+
+    $('#reset_chat_position').on('click', function () {
+        $('.chat').animate({
+            top: (!chat_original_position) ? "auto" : chat_original_position.top,
+            left: (!chat_original_position) ? "auto" : chat_original_position.left,
+            height: (!chat_original_size) ? "auto" : chat_original_size.hight,
+            width: (!chat_original_size) ? "auto" : chat_original_size.width,
+        })
+    })
+
     let timerId = setInterval(showClock2, 1000);
     showClock2(timerId)
 
@@ -53,10 +71,6 @@ $(document).on("turbolinks:load", function () {
         // 要素削除
         document.body.removeChild(tmp);
     });
-
-    $('#reset_chat_position').on('click', function () {
-        $('.item').removeAttr('style')
-    })
 
     //modalの設定
     if (location.href.match(/brainstorming/)) {

--- a/04.source/ideash/app/javascript/packs/shared/_right_menu.js
+++ b/04.source/ideash/app/javascript/packs/shared/_right_menu.js
@@ -12,8 +12,8 @@ $(document).on("turbolinks:load", function () {
             containment: "#wrap",
             handle: ".header-text",
             opacity: 0.5,
-            start: function (event, ui) {
-                chat_original_position = chat_original_position ?? ui.position;
+            create: function (event, ui) {
+                chat_original_position = $chat.position()
             }
         })
         .resizable({
@@ -27,10 +27,10 @@ $(document).on("turbolinks:load", function () {
 
     $('#reset_chat_position').on('click', function () {
         $('.chat').animate({
+            height: (!chat_original_size) ? "auto" : chat_original_size.height,
+            width: (!chat_original_size) ? "auto" : chat_original_size.width,
             top: (!chat_original_position) ? "auto" : chat_original_position.top,
             left: (!chat_original_position) ? "auto" : chat_original_position.left,
-            height: (!chat_original_size) ? "auto" : chat_original_size.hight,
-            width: (!chat_original_size) ? "auto" : chat_original_size.width,
         })
     })
 

--- a/04.source/ideash/app/javascript/packs/shared/_right_menu.js
+++ b/04.source/ideash/app/javascript/packs/shared/_right_menu.js
@@ -2,13 +2,20 @@ import {checkControllerAction} from "../common/check_controller_action";
 
 $(document).on("turbolinks:load", function () {
     if (!checkControllerAction(['brainstorming', 'mandarat'], ['edit'])) return
-
-    $('.chat').draggable({
-        containment: "#wrap",
-        handle: ".header-text",
-        opacity: 0.5,
-    });
-
+    // let $chat = $('.chat')
+    let $chat = $('.chat')
+    $chat
+        .draggable({
+            containment: "#wrap",
+            handle: ".header-text",
+            opacity: 0.5,
+        })
+        .resizable({
+            minHeight: 300,
+            minWidth:150,
+            handles: "e,s,w,se,sw"
+        });
+    console.log($chat.resizable)
     let timerId = setInterval(showClock2, 1000);
     showClock2(timerId)
 

--- a/04.source/ideash/app/javascript/packs/shared/_right_menu.js
+++ b/04.source/ideash/app/javascript/packs/shared/_right_menu.js
@@ -3,7 +3,9 @@ import {checkControllerAction} from "../common/check_controller_action";
 $(document).on("turbolinks:load", function () {
     if (!checkControllerAction(['brainstorming', 'mandarat'], ['edit'])) return
 
-    $('.chat').draggable();
+    $('.chat').draggable({
+        containment: "#wrap",
+    });
 
     let timerId = setInterval(showClock2, 1000);
     showClock2(timerId)

--- a/04.source/ideash/app/views/shared/_right_menu.html.erb
+++ b/04.source/ideash/app/views/shared/_right_menu.html.erb
@@ -57,42 +57,41 @@
   <button class="ui small button" id="reset_chat_position">
     チャットの位置リセット
   </button>
-
-  <div class="item chat">
-    <div class="header-text" title="ドラッグして移動">
-      chat
-      <%= image_tag "draggable.svg", id: "draggable_svg" %>
-    </div>
-    <div class="ui input mini chat-input">
-      <%= text_field_tag 'idea_chat', nil, placeholder: '話しかける...', data: {behavior: 'idea_speaker'} %>
-    </div>
-    <div class="chat-area">
-      <div class="inline field">
-        <div class="chat_contents">
-          <% preview_user_id = nil %>
-          <% for idea_log in @idea_logs.reverse %>
-            <% if idea_log.query['mode'] == 'chat' %>
-              <% if preview_user_id != idea_log.query['user_id'] %>
-                </div>
-                <div class="chat_content" name="chatuser_<%= idea_log.query['user_id'] %>">
-                  <h6 class="chat_username"><%= idea_log.query['chat']['user_name'] %></h6>
-              <% end %>
-              <% if current_user.id == idea_log.query['user_id'] %>
-                <div class="ui right pointing label chat_message"><%= idea_log.query['chat']['content'] %></div>
-              <% else %>
-                <div class="ui left pointing label chat_message"><%= idea_log.query['chat']['content'] %></div>
-              <% end %>
-              <% preview_user_id = idea_log.query['user_id'] %>
-            <% end %>
-          <% end %>
-          </div>
-          </div>
-    </div>
-  </div>
 </div>
 
 <div class="ui vertical icon menu right_menu" id="right_icon_menu">
   <a class="popup item" id="right_menu_show_button" data-content="メニューを開く" data-position="right center">
     <i class="angle double left grey icon"></i>
   </a>
+</div>
+
+<%# チャット欄 %>
+<div class="chat">
+  <div class="header-text" title="ドラッグして移動">
+    chat
+    <%= image_tag "draggable.svg", id: "draggable_svg" %>
+  </div>
+  <div class="ui input mini chat-input">
+    <%= text_field_tag 'idea_chat', nil, placeholder: '話しかける...', data: {behavior: 'idea_speaker'} %>
+  </div>
+  <div class="chat-area">
+    <div class="inline field chat_contents">
+      <% preview_user_id = nil %>
+      <% for idea_log in @idea_logs.reverse %>
+        <% if idea_log.query['mode'] == 'chat' %>
+          <% if preview_user_id != idea_log.query['user_id'] %>
+            <div class="chat_content" name="chatuser_<%= idea_log.query['user_id'] %>">
+              <h6 class="chat_username"><%= idea_log.query['chat']['user_name'] %></h6>
+          <% end %>
+          <% if current_user.id == idea_log.query['user_id'] %>
+            <div class="ui right pointing label chat_message"><%= idea_log.query['chat']['content'] %></div>
+          <% else %>
+            <div class="ui left pointing label chat_message"><%= idea_log.query['chat']['content'] %></div>
+          <% end %>
+          <% preview_user_id = idea_log.query['user_id'] %>
+        <% end %>
+      <% end %>
+      </div>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
チャット欄をrightmenuから分離しました。
チャット欄が再びドラッグできるようになりました。
　・チャット欄上部の部分だけドラッグできるようにしました
　・伴って上部のドラッグ可能領域ではカーソルがmoveになるように変更
　・ドラッグ中は透過するようにしました
チャット欄のりサイズが可能になしました。
　・左、右、下、右下、左下、右上、左上でリサイズ可能です。