### PR TITLE
ブレインストーミングのJSが二重に走る不具合に対処

### DIFF
--- a/04.source/ideash/app/views/shared/_right_menu.html.erb
+++ b/04.source/ideash/app/views/shared/_right_menu.html.erb
@@ -1,5 +1,4 @@
 <input type="hidden" id="user_id" value="<%= current_user.id %>">
-<%= javascript_pack_tag "idea/brainstorming_channel" %>
 <!-- 1 -->
 <div class="ui right fixed vertical menu block-edit-sidebar right_menu" id="right_menu">
   <a class="item" id="right_menu_hide_button">


### PR DESCRIPTION
right_menuに何故か読み込む処理が書かれていたため削除しました